### PR TITLE
Update GAAPICommon

### DIFF
--- a/src/SchedulingClients.Core/SchedulingClients.Core.csproj
+++ b/src/SchedulingClients.Core/SchedulingClients.Core.csproj
@@ -41,41 +41,41 @@
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/SchedulingClients.Core/packages.config
+++ b/src/SchedulingClients.Core/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/src/SchedulingClients.UI/SchedulingClients.UI.csproj
+++ b/src/SchedulingClients.UI/SchedulingClients.UI.csproj
@@ -32,41 +32,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/SchedulingClients.UI/packages.config
+++ b/src/SchedulingClients.UI/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tests/SchedulingClients.Core.SchedulingClientsConsole/SchedulingClients.Core.SchedulingClientsConsole.csproj
+++ b/tests/SchedulingClients.Core.SchedulingClientsConsole/SchedulingClients.Core.SchedulingClientsConsole.csproj
@@ -33,26 +33,26 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="CommandLine, Version=2.8.0.0, Culture=neutral, PublicKeyToken=5a870481e358d379, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CommandLineParser.2.8.0\lib\net461\CommandLine.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/tests/SchedulingClients.Core.SchedulingClientsConsole/packages.config
+++ b/tests/SchedulingClients.Core.SchedulingClientsConsole/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="CommandLineParser" version="2.8.0" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tests/SchedulingClients.Core.Test/SchedulingClients.Core.Test.csproj
+++ b/tests/SchedulingClients.Core.Test/SchedulingClients.Core.Test.csproj
@@ -34,38 +34,38 @@
     <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.4.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.16.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.16.1\lib\net45\Moq.dll</HintPath>
@@ -74,7 +74,7 @@
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.3.13.1\lib\net45\nunit.framework.dll</HintPath>

--- a/tests/SchedulingClients.Core.Test/packages.config
+++ b/tests/SchedulingClients.Core.Test/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Castle.Core" version="4.4.1" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="Moq" version="4.16.1" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="NUnit" version="3.13.1" targetFramework="net472" />
   <package id="NUnit3TestAdapter" version="3.17.0" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />

--- a/tests/SchedulingClients.DemoApp/SchedulingClients.DemoApp.csproj
+++ b/tests/SchedulingClients.DemoApp/SchedulingClients.DemoApp.csproj
@@ -35,41 +35,41 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/tests/SchedulingClients.DemoApp/packages.config
+++ b/tests/SchedulingClients.DemoApp/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tutorials/Tutorial 01/App.config
+++ b/tutorials/Tutorial 01/App.config
@@ -1,6 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup>
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/tutorials/Tutorial 01/Tutorial 01.csproj
+++ b/tutorials/Tutorial 01/Tutorial 01.csproj
@@ -33,50 +33,50 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FleetClients.Core, Version=3.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FleetClients.3.1.6\lib\net472\FleetClients.Core.dll</HintPath>
+    <Reference Include="FleetClients.Core, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FleetClients.3.3.0\lib\net472\FleetClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FleetClients.UI, Version=3.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FleetClients.3.1.6\lib\net472\FleetClients.UI.dll</HintPath>
+    <Reference Include="FleetClients.UI, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FleetClients.3.3.0\lib\net472\FleetClients.UI.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/tutorials/Tutorial 01/packages.config
+++ b/tutorials/Tutorial 01/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.8.2" targetFramework="net472" />
-  <package id="FleetClients" version="3.1.6" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="FleetClients" version="3.3.0" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tutorials/Tutorial 02/Tutorial 02.csproj
+++ b/tutorials/Tutorial 02/Tutorial 02.csproj
@@ -33,23 +33,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/tutorials/Tutorial 02/packages.config
+++ b/tutorials/Tutorial 02/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/tutorials/Tutorial 03/App.config
+++ b/tutorials/Tutorial 03/App.config
@@ -9,6 +9,10 @@
         <assemblyIdentity name="Xceed.Wpf.Toolkit" publicKeyToken="3e4669d2f30244f4" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/tutorials/Tutorial 03/Tutorial 03.csproj
+++ b/tutorials/Tutorial 03/Tutorial 03.csproj
@@ -33,50 +33,50 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BaseClients.Architecture, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Architecture.dll</HintPath>
+    <Reference Include="BaseClients.Architecture, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="BaseClients.Core, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\BaseClients.2.1.2\lib\net472\BaseClients.Core.dll</HintPath>
+    <Reference Include="BaseClients.Core, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\BaseClients.2.2.0\lib\net472\BaseClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FleetClients.Core, Version=3.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FleetClients.3.1.6\lib\net472\FleetClients.Core.dll</HintPath>
+    <Reference Include="FleetClients.Core, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FleetClients.3.3.0\lib\net472\FleetClients.Core.dll</HintPath>
     </Reference>
-    <Reference Include="FleetClients.UI, Version=3.1.6.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FleetClients.3.1.6\lib\net472\FleetClients.UI.dll</HintPath>
+    <Reference Include="FleetClients.UI, Version=3.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FleetClients.3.3.0\lib\net472\FleetClients.UI.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Architecture, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
+    <Reference Include="GAAPICommon.Architecture, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GAAPICommon.Core, Version=1.38.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GAAPICommon.1.38.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
+    <Reference Include="GAAPICommon.Core, Version=1.39.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GAAPICommon.1.39.1\lib\netstandard2.0\GAAPICommon.Core.dll</HintPath>
     </Reference>
-    <Reference Include="GACore, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.dll</HintPath>
+    <Reference Include="GACore, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Architecture, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Architecture.dll</HintPath>
+    <Reference Include="GACore.Architecture, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Architecture.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Controls, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Controls.dll</HintPath>
+    <Reference Include="GACore.Controls, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Controls.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.Extensions, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.Extensions.dll</HintPath>
+    <Reference Include="GACore.Extensions, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="GACore.UI, Version=2.5.3.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\GACore.2.5.3\lib\net472\GACore.UI.dll</HintPath>
+    <Reference Include="GACore.UI, Version=2.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\GACore.2.6.0\lib\net472\GACore.UI.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.31\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.39\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
     <Reference Include="MoreLinq, Version=3.3.2.0, Culture=neutral, PublicKeyToken=384d532d7e88985d, processorArchitecture=MSIL">
       <HintPath>..\..\packages\morelinq.3.3.2\lib\net451\MoreLinq.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NLog.4.7.8\lib\net45\NLog.dll</HintPath>
+      <HintPath>..\..\packages\NLog.4.7.9\lib\net45\NLog.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/tutorials/Tutorial 03/packages.config
+++ b/tutorials/Tutorial 03/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BaseClients" version="2.1.2" targetFramework="net472" />
+  <package id="BaseClients" version="2.2.0" targetFramework="net472" />
   <package id="Extended.Wpf.Toolkit" version="3.5.0" targetFramework="net472" />
-  <package id="FleetClients" version="3.1.6" targetFramework="net472" />
-  <package id="GAAPICommon" version="1.38.1" targetFramework="net472" />
-  <package id="GACore" version="2.5.3" targetFramework="net472" />
-  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.31" targetFramework="net472" />
+  <package id="FleetClients" version="3.3.0" targetFramework="net472" />
+  <package id="GAAPICommon" version="1.39.1" targetFramework="net472" />
+  <package id="GACore" version="2.6.0" targetFramework="net472" />
+  <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.39" targetFramework="net472" />
   <package id="morelinq" version="3.3.2" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="NLog" version="4.7.8" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="NLog" version="4.7.9" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Update BaseClients to 2.2.0
Update FleetClients to 3.3.0
Update to GAAPICommon 1.39.1
Update GACore to 2.6.0
Update Microsoft.Xaml.Behaviors.Wpf to 1.1.39 (to match Atlas II SS)
Update Newtonsoft.Json to 13.0.1 (to match Atlas II SS)
Update to NLog 4.7.9 (to match Atlas II SS)